### PR TITLE
made tenant id optional

### DIFF
--- a/v1/access_tokens_test.go
+++ b/v1/access_tokens_test.go
@@ -132,9 +132,9 @@ func TestCreateDeploymentAccessToken_TenantIDValidation(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name:     "invalid empty string",
+			name:     "valid empty string (tenant ID is optional)",
 			tenantID: "",
-			wantErr:  true,
+			wantErr:  false,
 		},
 		{
 			name:     "invalid letters",

--- a/v1/client.go
+++ b/v1/client.go
@@ -197,7 +197,7 @@ func (a *VMCloudAPIClient) CreateDeploymentAccessToken(ctx context.Context, depl
 	if token.Type != AccessModeRead && token.Type != AccessModeWrite && token.Type != AccessModeReadWrite {
 		return AccessToken{}, fmt.Errorf("invalid access token type: %s", token.Type)
 	}
-	if !isValidTenantID(token.TenantID) {
+	if token.TenantID != "" && !isValidTenantID(token.TenantID) {
 		return AccessToken{}, fmt.Errorf("invalid tenant ID format: %s, expected <accountID> or <accountID>:<projectID>", token.TenantID)
 	}
 	body, err := json.Marshal(token)


### PR DESCRIPTION
introduced in https://github.com/VictoriaMetrics/victoriametrics-cloud-api-go/pull/5 change now requires tenant ID to be set, which is not mandatory per our docs and makes no sense in context of single node